### PR TITLE
Add nginx rate limiting to login API

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,6 +46,7 @@ http {
     limit_req_status 429;
     limit_req_zone $post_binary_remote_addr zone=sample:10m rate=6r/m;
     limit_req_zone $post_binary_remote_addr zone=create-account:10m rate=1r/s;
+    limit_req_zone $post_binary_remote_addr zone=login:10m rate=1r/s;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256;
@@ -266,6 +267,14 @@ http {
                 deny all;
             }
             limit_req zone=create-account burst=10 nodelay;
+        }
+        
+        location = /api/login {
+            proxy_pass http://backend;
+            limit_except POST {
+                deny all;
+            }
+            limit_req zone=login burst=10 nodelay;
         }
 
         location ^~ /api/ {


### PR DESCRIPTION
Signed-off-by: June <june@eridan.me>

Untested, but it is the same as the create-account rate limit.

Might solve https://github.com/GrapheneOS/AttestationServer/issues/58