### PR TITLE
Sync Attestation library with upstream CTS (android-cts-12.0_r3)

### DIFF
--- a/src/main/java/app/attestation/server/attestation/Asn1Utils.java
+++ b/src/main/java/app/attestation/server/attestation/Asn1Utils.java
@@ -37,7 +37,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Set;
 
-class Asn1Utils {
+public class Asn1Utils {
 
     public static int getIntegerFromAsn1(ASN1Encodable asn1Value)
             throws CertificateParsingException {
@@ -62,7 +62,7 @@ class Asn1Utils {
 
     public static byte[] getByteArrayFromAsn1(ASN1Encodable asn1Encodable)
             throws CertificateParsingException {
-        if (asn1Encodable == null || !(asn1Encodable instanceof DEROctetString)) {
+        if (!(asn1Encodable instanceof DEROctetString)) {
             throw new CertificateParsingException("Expected DEROctetString");
         }
         ASN1OctetString derOctectString = (ASN1OctetString) asn1Encodable;
@@ -136,11 +136,30 @@ class Asn1Utils {
 
     public static boolean getBooleanFromAsn1(ASN1Encodable value)
             throws CertificateParsingException {
+        return getBooleanFromAsn1(value, true);
+    }
+
+    public static boolean getBooleanFromAsn1(ASN1Encodable value, boolean strictParsing)
+            throws CertificateParsingException {
         if (!(value instanceof ASN1Boolean)) {
             throw new CertificateParsingException(
                     "Expected boolean, found " + value.getClass().getName());
         }
-        return ((ASN1Boolean) value).isTrue();
+        ASN1Boolean booleanValue = (ASN1Boolean) value;
+
+        if (booleanValue.equals(ASN1Boolean.TRUE)) {
+            return true;
+        } else if (booleanValue.equals((ASN1Boolean.FALSE))) {
+            return false;
+        } else if (!strictParsing) {
+            // Value is not 0xFF nor 0x00, but some other non-zero value.
+            // This is invalid DER, but if we're not being strict,
+            // consider it true, otherwise fall through and throw exception
+            return true;
+        }
+
+        throw new CertificateParsingException(
+                "DER-encoded boolean values must contain either 0x00 or 0xFF");
     }
 
     private static int bigIntegerToInt(BigInteger bigInt) throws CertificateParsingException {

--- a/src/main/java/app/attestation/server/attestation/Attestation.java
+++ b/src/main/java/app/attestation/server/attestation/Attestation.java
@@ -17,17 +17,22 @@
 package app.attestation.server.attestation;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
 import org.bouncycastle.asn1.ASN1Sequence;
 
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.util.Set;
 
 /**
  * Parses an attestation certificate and provides an easy-to-use interface for examining the
  * contents.
  */
 public class Attestation {
+    static final String EAT_OID = "1.3.6.1.4.1.11129.2.1.25";
+    static final String ASN1_OID = "1.3.6.1.4.1.11129.2.1.17";
+    static final String KEY_USAGE_OID = "2.5.29.15"; // Standard key usage extension.
     static final String KEY_DESCRIPTION_OID = "1.3.6.1.4.1.11129.2.1.17";
     static final int ATTESTATION_VERSION_INDEX = 0;
     static final int ATTESTATION_SECURITY_LEVEL_INDEX = 1;
@@ -40,6 +45,17 @@ public class Attestation {
 
     public static final int KM_SECURITY_LEVEL_SOFTWARE = 0;
     public static final int KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT = 1;
+    public static final int KM_SECURITY_LEVEL_STRONG_BOX = 2;
+
+    // Known KeyMaster/KeyMint versions. This is the version number
+    // which appear in the keymasterVersion field.
+    public static final int KM_VERSION_KEYMASTER_1 = 10;
+    public static final int KM_VERSION_KEYMASTER_1_1 = 11;
+    public static final int KM_VERSION_KEYMASTER_2 = 20;
+    public static final int KM_VERSION_KEYMASTER_3 = 30;
+    public static final int KM_VERSION_KEYMASTER_4 = 40;
+    public static final int KM_VERSION_KEYMASTER_4_1 = 41;
+    public static final int KM_VERSION_KEYMINT_1 = 100;
 
     private final int attestationVersion;
     private final int attestationSecurityLevel;
@@ -49,14 +65,17 @@ public class Attestation {
     private final byte[] uniqueId;
     private final AuthorizationList softwareEnforced;
     private final AuthorizationList teeEnforced;
-
+    private final Set<String> unexpectedExtensionOids;
 
     /**
      * Constructs an {@code Attestation} object from the provided {@link X509Certificate},
      * extracting the attestation data from the attestation extension.
      *
+     * <p>This method ensures that at most one attestation extension is included in the certificate.
+     *
      * @throws CertificateParsingException if the certificate does not contain a properly-formatted
-     *                                     attestation extension.
+     *     attestation extension, if it contains multiple attestation extensions, or if the
+     *     attestation extension can not be parsed.
      */
     public Attestation(X509Certificate x509Cert) throws CertificateParsingException {
         ASN1Sequence seq = getAttestationSequence(x509Cert);
@@ -73,6 +92,7 @@ public class Attestation {
 
         softwareEnforced = new AuthorizationList(seq.getObjectAt(SW_ENFORCED_INDEX));
         teeEnforced = new AuthorizationList(seq.getObjectAt(TEE_ENFORCED_INDEX));
+        unexpectedExtensionOids = retrieveUnexpectedExtensionOids(x509Cert);
     }
 
     public static String securityLevelToString(int attestationSecurityLevel) {
@@ -81,6 +101,8 @@ public class Attestation {
                 return "Software";
             case KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT:
                 return "TEE";
+            case KM_SECURITY_LEVEL_STRONG_BOX:
+                return "StrongBox";
             default:
                 return "Unknown";
         }
@@ -94,6 +116,7 @@ public class Attestation {
         return attestationSecurityLevel;
     }
 
+    // Returns one of the KM_VERSION_* values define above.
     public int getKeymasterVersion() {
         return keymasterVersion;
     }
@@ -118,16 +141,22 @@ public class Attestation {
         return teeEnforced;
     }
 
+    public Set<String> getUnexpectedExtensionOids() {
+        return unexpectedExtensionOids;
+    }
+
     @Override
     public String toString() {
         StringBuilder s = new StringBuilder();
-        s.append("Attest version: " + attestationVersion);
-        s.append("\nAttest security: " + securityLevelToString(attestationSecurityLevel));
+        s.append("Extension type: " + getClass());
+        s.append("\nAttest version: " + attestationVersion);
+        s.append("\nAttest security: " + securityLevelToString(getAttestationSecurityLevel()));
         s.append("\nKM version: " + keymasterVersion);
         s.append("\nKM security: " + securityLevelToString(keymasterSecurityLevel));
 
         s.append("\nChallenge");
-        String stringChallenge = new String(attestationChallenge);
+        String stringChallenge =
+                attestationChallenge != null ? new String(attestationChallenge) : "null";
         if (CharMatcher.ascii().matchesAllOf(stringChallenge)) {
             s.append(": [" + stringChallenge + "]");
         } else {
@@ -155,4 +184,16 @@ public class Attestation {
         return Asn1Utils.getAsn1SequenceFromBytes(attestationExtensionBytes);
     }
 
+    Set<String> retrieveUnexpectedExtensionOids(X509Certificate x509Cert) {
+        return new ImmutableSet.Builder<String>()
+                .addAll(
+                        x509Cert.getCriticalExtensionOIDs().stream()
+                                .filter(s -> !KEY_USAGE_OID.equals(s))
+                                .iterator())
+                .addAll(
+                        x509Cert.getNonCriticalExtensionOIDs().stream()
+                                .filter(s -> !ASN1_OID.equals(s) && !EAT_OID.equals(s))
+                                .iterator())
+                .build();
+    }
 }

--- a/src/main/java/app/attestation/server/attestation/AttestationApplicationId.java
+++ b/src/main/java/app/attestation/server/attestation/AttestationApplicationId.java
@@ -19,6 +19,8 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1Set;
 
 import java.security.cert.CertificateParsingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,7 +133,7 @@ public class AttestationApplicationId implements java.lang.Comparable<Attestatio
         return result;
     }
 
-    private class ByteArrayComparator implements java.util.Comparator<byte[]> {
+    private static class ByteArrayComparator implements java.util.Comparator<byte[]> {
         @Override
         public int compare(byte[] a, byte[] b) {
             int res = Integer.compare(a.length, b.length);

--- a/src/main/java/app/attestation/server/attestation/AttestationPackageInfo.java
+++ b/src/main/java/app/attestation/server/attestation/AttestationPackageInfo.java
@@ -70,7 +70,6 @@ public class AttestationPackageInfo implements java.lang.Comparable<AttestationP
         int res = packageName.compareTo(other.packageName);
         if (res != 0) return res;
         res = Long.compare(version, other.version);
-        if (res != 0) return res;
         return res;
     }
 

--- a/src/main/java/app/attestation/server/attestation/RootOfTrust.java
+++ b/src/main/java/app/attestation/server/attestation/RootOfTrust.java
@@ -39,6 +39,11 @@ public class RootOfTrust {
     private final byte[] verifiedBootHash;
 
     public RootOfTrust(ASN1Encodable asn1Encodable) throws CertificateParsingException {
+        this(asn1Encodable, true);
+    }
+
+    public RootOfTrust(ASN1Encodable asn1Encodable, boolean strictParsing)
+            throws CertificateParsingException {
         if (!(asn1Encodable instanceof ASN1Sequence)) {
             throw new CertificateParsingException("Expected sequence for root of trust, found "
                     + asn1Encodable.getClass().getName());
@@ -47,7 +52,8 @@ public class RootOfTrust {
         ASN1Sequence sequence = (ASN1Sequence) asn1Encodable;
         verifiedBootKey =
                 Asn1Utils.getByteArrayFromAsn1(sequence.getObjectAt(VERIFIED_BOOT_KEY_INDEX));
-        deviceLocked = Asn1Utils.getBooleanFromAsn1(sequence.getObjectAt(DEVICE_LOCKED_INDEX));
+        deviceLocked = Asn1Utils.getBooleanFromAsn1(
+                sequence.getObjectAt(DEVICE_LOCKED_INDEX), strictParsing);
         verifiedBootState =
                 Asn1Utils.getIntegerFromAsn1(sequence.getObjectAt(VERIFIED_BOOT_STATE_INDEX));
         if (sequence.size() < 4) {
@@ -92,7 +98,9 @@ public class RootOfTrust {
     @Override
     public String toString() {
         return "\nVerified boot Key: " +
-                BaseEncoding.base16().encode(verifiedBootKey) +
+                (verifiedBootKey != null ?
+                        BaseEncoding.base64().encode(verifiedBootKey) :
+                        "null") +
                 "\nDevice locked: " +
                 deviceLocked +
                 "\nVerified boot state: " +


### PR DESCRIPTION
Signed-off-by: June <june@eridan.me>

Notable changes/additions:

- Strict mode / strictParsing
- KeyMaster Strongbox Security Level (Software, TEE, Strongbox) (KM_SECURITY_LEVEL_STRONG_BOX)
- New overloaded method AttestationApplicationId uses Android PackageManager and PM Signature
- unexpectedExtensionOids (?)
- getRootOfTrust and getSecurityLevel

I have not tested this, but it builds and Android Studio has no errors.