### PR TITLE
Add more documentation for self hosting AttestationServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ See the overview of the project at https://attestation.app/about.
 
 This is a generic guide on setting up the attestation server.
 
+Sync submodules for sqlite4java prebuilt in libs/.
+
 You need to set up nginx using the nginx configuration in the nginx directory in this repository.
 You'll need to adjust it based on your domain name. The sample configuration relies on certbot,
 [nginx-rotate-session-ticket-keys](https://github.com/GrapheneOS/nginx-rotate-session-ticket-keys),
@@ -27,7 +29,10 @@ Set up ssh `authorized_keys` for the attestation user.
 
 Copy `attestation.service` to `/etc/systemd/system/attestation.service`.
 
-On your development machine, you will need to change the `remote` variable in the scripts to your server. Then deploy the attestation server and static content:
+On your development machine, you will need to change the `remote` variable in the deploy scripts to your server. You'll also need to change the
+[DOMAIN](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationServer.java#L83) in
+AttestationServer.java to your server and the [app signing key](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationProtocol.java#L173-L174) and [app ID](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationProtocol.java#L169).
+Then deploy the attestation server and static content:
 
     ./deploy-server
     ./deploy-static
@@ -37,7 +42,7 @@ As root on the server, enable and start the attestation server:
     systemctl enable attestation
     systemctl start attestation
 
-The server will be listening on `[::1]:8080` by default which [can be changed](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationServer.java#L381).
+The server will be listening on `[::1]:8080` by default which [can be changed](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationServer.java#L371).
 
 ## Email alert configuration
 
@@ -61,7 +66,7 @@ include your DNS server and mail server IP addresses when using a remote mail se
 ### Handling abuse
 
 The `emailBlacklistPatterns` array in
-`src/main/java/app/attestation/server/AttestationServer.java` can be used to blacklist email
+[`src/main/java/app/attestation/server/AttestationServer.java`](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationServer.java#L90-L92) can be used to blacklist email
 addresses using regular expressions. We plan to move this to a table in the database so that it
 can be configured dynamically without modifying the sources, rebuilding and redeploying. For now,
 this was added to quickly provide a way to counter abuse.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ You'll need to adjust it based on your domain name. The sample configuration rel
 [nginx-rotate-session-ticket-keys](https://github.com/GrapheneOS/nginx-rotate-session-ticket-keys),
 and [certbot-ocsp-fetcher](https://github.com/tomwassenberg/certbot-ocsp-fetcher). Setting up the web server is out-of-scope for this guide.
 
+
+The deploy and process scripts on the development machine require the following dependencies to be installed:
+
+    rsync, zopfli, parallel, yajl, brotli, nginx-mod-brotli, python3, python-pip, nodejs, npm, libxml2
+
+`validatornu` must be obtained manually [here](https://github.com/validator/validator/releases/tag/20.6.30) (vnu.linux.zip).
+Unzip it in the same directory in AttestationServer and change the binary path in `process-static` from `validatornu`
+to `vnu-runtime-image/bin/vnu` using sed: `sed -i 's+validatornu+vnu-runtime-image/bin/vnu+g' process-static`
+
 Install a headless Java 18 runtime environment. The package name on Debian-based distributions is
 `openjdk-18-jre-headless` or `jre-openjdk-headless` on Arch Linux. Install `sqlite3` in order to set up the email configuration for the
 database.
@@ -34,6 +43,10 @@ On your development machine, you will need to change the `remote` variable in th
 AttestationServer.java to your server and the [app signing key](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationProtocol.java#L173-L174) and [app ID](https://github.com/GrapheneOS/AttestationServer/blob/main/src/main/java/app/attestation/server/AttestationProtocol.java#L169).
 Then deploy the attestation server and static content:
 
+    npm i
+    python -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
     ./deploy-server
     ./deploy-static
 


### PR DESCRIPTION
A lot of the instructions are very not-obvious, especially the process-static scripts.