### PR TITLE
Explicitly use UTF-8 encoding for Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
This is due to different encoding when building on Windows

C:\Users\Terezi Pyrope\AttestationServer\src\main\java\app\attestation\server\AttestationProtocol.java:241: error: unmappable character (0x81) for encoding windows-1252
    private static final String DEVICE_MOTO_G7 = "Motorola moto g�?�";
                                                                  ^

Signed-off-by: June <aobugene@reliaquest.com>