### PR TITLE
Correct regex in process-static

### DIFF
--- a/process-static
+++ b/process-static
@@ -80,5 +80,5 @@ zopfli_preserve_time() {
 }
 export -f zopfli_preserve_time
 
-find static-tmp -regex '.+\.\(css\|html\|ico\|js\|json\|svg\|txt\|webmanifest\|xml\)' |
+find static-tmp -regex '.\+\.\(css\|html\|ico\|js\|json\|svg\|txt\|webmanifest\|xml\)' |
     parallel -q ::: brotli_k zopfli_preserve_time :::: -


### PR DESCRIPTION
Add a blackslash to be compliant against the BRE syntax (see https://www.gnu.org/software/sed/manual/html_node/BRE-syntax.html) otherwise the command doesn't work with the regex type posix-basic.