### PR TITLE
Update Google Play Store link to the correct one

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -85,7 +85,7 @@
             <h1 id="device-integrity-monitoring">
                 <a href="#device-integrity-monitoring">Device integrity monitoring</a>
             </h1>
-            <p>Hardware-based remote attestation service for monitoring the security of Android devices using <a href="https://play.google.com/store/apps/details?id=app.attestation.auditor">the Auditor app</a>. For more details, see the <a href="/about">detailed description of the app and service</a> and the <a href="/tutorial">usage instructions</a>.</p>
+            <p>Hardware-based remote attestation service for monitoring the security of Android devices using <a href="https://play.google.com/store/apps/details?id=app.attestation.auditor.play">the Auditor app</a>. For more details, see the <a href="/about">detailed description of the app and service</a> and the <a href="/tutorial">usage instructions</a>.</p>
             <div id="account_content" hidden="">
                 <p>Subscribe a device to regularly submitting attestations to this account by pressing 'Enable remote verification' in the Auditor app menu and scanning the QR code for this account:</p>
                 <section id="pairing">


### PR DESCRIPTION
This PR updates the link to the Play Store on the attestation.app homepage to reflect the correct version, as the other one is now deprecated.