### PR TITLE
Update minimum Android version to be Auditor

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -102,7 +102,7 @@
                     <a href="#device-support">Device support</a>
                 </h2>
 
-                <p>Any device with Android 8.0 or later can run the Auditor app and use it to verify
+                <p>Any device with Android 10 or later can run the Auditor app and use it to verify
                 other devices. However, only devices <em>launched</em> with Android 8.0 or later have
                 the necessary hardware support for being verified. Each device model also needs to be
                 explicitly integrated into the app. The following devices are currently supported by

--- a/static/tutorial.html
+++ b/static/tutorial.html
@@ -77,7 +77,7 @@
                 <p>The device being verified (Auditee) must be one of the supported devices. Android
                 developer previews aren't supported since the hardware verified version is set to a
                 placeholder value. The device performing verification (Auditor) just needs to be any
-                Android 8.0+ compatible device with a camera.</p>
+                Android 10+ compatible device with a camera.</p>
 
                 <ol>
                     <li>press Auditor on the device that will be verifying the Auditee</li>


### PR DESCRIPTION
This PR changes minimum Android version to be Auditor. It doesn't change wording on when devices can be audited, since it is still true that devices *launched* with Android 8 (but no longer on that version) can be audited.