### PR TITLE
Standardize the size of the QR codes on the Donate page

### DIFF
--- a/static/donate.html
+++ b/static/donate.html
@@ -76,7 +76,7 @@
 
                 <div class="coin-address">
                     <a href="bitcoin:bc1quxrwjhgvmx4rnyfzhvlqmjuh9nry7n54nhnfn9?label=attestation.app&amp;message=Donation%20to%20attestation.app" rel="nofollow">
-                        <img src="/donate-bitcoin.png" alt="Bitcoin donation QR code" width="196" height="196"/>
+                        <img src="/donate-bitcoin.png" alt="Bitcoin donation QR code"/>
                         <p>bc1quxrwjhgvmx4rnyfzhvlqmjuh9nry7n54nhnfn9</p>
                     </a>
                 </div>
@@ -85,7 +85,7 @@
 
                 <div class="coin-address">
                     <a href="bitcoin:bc1pqpelts7dvuuxqk7gk72wzc9u3xh0nddkk40p0lxkr2gq5ktjm5qsw0rgvn?label=attestation.app&amp;message=Donation%20to%20attestation.app" rel="nofollow">
-                        <img src="/donate-bitcoin-taproot.png" alt="Bitcoin Taproot donation QR code" width="196" height="196"/>
+                        <img src="/donate-bitcoin-taproot.png" alt="Bitcoin Taproot donation QR code"/>
                         <p>bc1pqpelts7dvuuxqk7gk72wzc9u3xh0nddkk40p0lxkr2gq5ktjm5qsw0rgvn</p>
                     </a>
                 </div>
@@ -102,7 +102,7 @@
 
                 <div class="coin-address">
                     <a href="monero:83Y2VmZ7ZhM6C4pQFg5EPzQZyCk9vjbb6D3R1oT6tjyz5T8evvgpnCc7PHafxV43upMRJmCBn8ZoTXoQMSLoVbApHFub47u?recipient_name=attestation.app&amp;tx_description=Donation%20to%20attestation.app" rel="nofollow">
-                        <img src="/donate-monero.png" alt="Monero donation QR code" width="228" height="228"/>
+                        <img src="./donate-monero.png" alt="Monero donation QR code"/>
                         <p>83Y2VmZ7ZhM6C4pQFg5EPzQZyCk9vjbb6D3R1oT6tjyz5T8evvgpnCc7PHafxV43upMRJmCBn8ZoTXoQMSLoVbApHFub47u</p>
                     </a>
                 </div>
@@ -125,7 +125,7 @@
 
                 <div class="coin-address">
                     <a href="zcash:t1Z8ks4yBsz4B4Nb647kT8cn2C6zuKZBCkB?label=attestation.app&amp;message=Donation%20to%20attestation.app" rel="nofollow">
-                        <img src="/donate-zcash-transparent.png" alt="Transparent Zcash donation QR code" width="180" height="180"/>
+                        <img src="/donate-zcash-transparent.png" alt="Transparent Zcash donation QR code"/>
                         <p>t1dsDbZQZrEUEGanmPMTAGxY2PJowL2S4br</p>
                     </a>
                 </div>
@@ -138,7 +138,7 @@
 
                 <div class="coin-address">
                     <a href="ethereum:0x4de3e9Ebcf061a8923d5f41244A8793cF7172b33" rel="nofollow">
-                        <img src="/donate-ethereum.png" alt="Ethereum donation QR code" width="148" height="148"/>
+                        <img src="/donate-ethereum.png" alt="Ethereum donation QR code"/>
                         <p>0x4de3e9Ebcf061a8923d5f41244A8793cF7172b33</p>
                     </a>
                 </div>
@@ -153,7 +153,7 @@
 
                 <div class="coin-address">
                     <a href="web+cardano:addr1qxst0vhff5hx9n8cds7mzc3yrdtaxrs6kjsevf06urerq8u29gwxlt6f8pavhx2hjuw6494sxny8te7lrs0c6237u9ps25n99g" rel="nofollow">
-                        <img src="/donate-cardano.png" alt="Cardano donation QR code" width="196" height="196"/>
+                        <img src="/donate-cardano.png" alt="Cardano donation QR code"/>
                         <p>addr1qxst0vhff5hx9n8cds7mzc3yrdtaxrs6kjsevf06urerq8u29gwxlt6f8pavhx2hjuw6494sxny8te7lrs0c6237u9ps25n99g</p>
                     </a>
                 </div>

--- a/static/main.css
+++ b/static/main.css
@@ -127,6 +127,9 @@ input {
 
 .coin-address img {
     image-rendering: pixelated;
+    width: 180px;
+    height: 180px;
+    border-radius: 16px;
 }
 
 /* latin */


### PR DESCRIPTION
This saves space on the page and improves consistency.
Also adds a slight curve to the corners of the QR codes.

Before:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/a5c466b6-e678-4269-ae7f-765cef2b7c70" width="50%">

After:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/2defd6aa-3f33-4de3-9948-572dd28245b4" width="50%">
