### PR TITLE
Correct max standard tier for GitHub Sponsors

### DIFF
--- a/static/donate.html
+++ b/static/donate.html
@@ -67,7 +67,7 @@
 
                 <p>Auditor can be sponsored with recurring or one-time donations via credit
                 cards through <a href="https://github.com/sponsors/thestinger">GitHub
-                Sponsors</a>. There are standard tiers from $5 to $250 or you can donate a custom
+                Sponsors</a>. There are standard tiers from $5 to $5,000 or you can donate a custom
                 amount.</p>
             </section>
 


### PR DESCRIPTION
This PR corrects the max standard tier amount in the donation page from $250 to $5,000.