### PR TITLE
state username and password requirements

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -72,6 +72,7 @@
                 <details>
                     <summary class="centered-text">Further information about accounts</summary>
                     <div>
+                        <p>Username can contain any character from the 26 letter Latin alphabet as well as numbers and can be up to 32 characters long. Password can contain any Unicode character and can be 8 to 256 characters long.</p>
                         <p>For security reasons, accounts are not tied to email addresses. Adding an alert email to your account does not provide a recovery method. If you forget your password, you'll need to make a new account and move your devices over to it.</p>
                         <p>Accounts with no paired devices are deleted after 365 days without a successful login. Paired devices expire after 90 days without submitting a valid attestation.</p>
                     </div>


### PR DESCRIPTION
HTML attributes help password managers suggest passwords and aid autofill, however the browser does not tell the user what the requirements are, just to meet them to proceed.