### PR TITLE
fix two minor bugs in request handling

### DIFF
--- a/src/main/java/app/attestation/server/AttestationServer.java
+++ b/src/main/java/app/attestation/server/AttestationServer.java
@@ -1987,12 +1987,12 @@ class AttestationServer {
             final ByteArrayOutputStream attestation = new ByteArrayOutputStream();
             final byte[] buffer = new byte[4096];
             for (int read = input.read(buffer); read != -1; read = input.read(buffer)) {
-                attestation.write(buffer, 0, read);
-
-                if (attestation.size() > AttestationProtocol.MAX_MESSAGE_SIZE) {
+                if (attestation.size() + read > AttestationProtocol.MAX_MESSAGE_SIZE) {
                     exchange.sendResponseHeaders(413, -1);
                     return;
                 }
+
+                attestation.write(buffer, 0, read);
             }
 
             final byte[] attestationResult = attestation.toByteArray();

--- a/src/main/java/app/attestation/server/AttestationServer.java
+++ b/src/main/java/app/attestation/server/AttestationServer.java
@@ -76,7 +76,7 @@ class AttestationServer {
 
     private static final int DEFAULT_VERIFY_INTERVAL = 6 * 60 * 60;
     private static final int MIN_VERIFY_INTERVAL = 60 * 60;
-    private static final int MAX_VERIFY_INTERVAL = 7 * 24 * 70 * 60;
+    private static final int MAX_VERIFY_INTERVAL = 7 * 24 * 60 * 60;
     private static final int DEFAULT_ALERT_DELAY = 48 * 60 * 60;
     private static final int MIN_ALERT_DELAY = 32 * 60 * 60;
     private static final int MAX_ALERT_DELAY = 2 * 7 * 24 * 60 * 60;


### PR DESCRIPTION
- `MAX_VERIFY_INTERVAL` was `7 * 24 * 70 * 60` (~8.2 days) due to a `70` typo where `60` was intended I believe

- `VerifyHandler` checked the accumulated size *after* writing each 4 KiB chunk, allowing the buffer to briefly exceed `MAX_MESSAGE_SIZE` by up to 4095 bytes before rejection. Check before writing, matching the correct pattern already used by `SubmitHandler`.